### PR TITLE
add withErrorHandler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-api-route-middleware",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-api-route-middleware",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "next": "^12.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-api-route-middleware",
   "author": "kolbysisk",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Middleware for nextjs api routes",
   "license": "MIT",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from './use';
-export * from './run-middlewares';
 export * from './types';

--- a/src/run-middlewares.ts
+++ b/src/run-middlewares.ts
@@ -1,25 +1,38 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { Middleware } from './types';
+import { ErrorHandler, Middleware } from './types';
 
 export async function runMiddlewares<RequestT extends NextApiRequest>(
   req: RequestT,
   res: NextApiResponse,
   middlewares: Middleware<RequestT>[],
-  currentMiddlewareIndex: number
+  currentMiddlewareIndex: number,
+  errorHandler?: ErrorHandler
 ) {
-  // Check if previous middleware sent a response - if it did we stop execution
-  if (res.headersSent) return;
+  const middleware = async () => {
+    // Check if previous middleware sent a response - if it did we stop execution
+    if (res.headersSent) return;
 
-  const next = async () => {
-    // Get next middleware, if there is one - if there isn't we stop execution
-    const nextMiddleware = middlewares[currentMiddlewareIndex + 1];
-    if (!nextMiddleware) return;
+    const next = async () => {
+      // Get next middleware, if there is one - if there isn't we stop execution
+      const nextMiddleware = middlewares[currentMiddlewareIndex + 1];
+      if (!nextMiddleware) return;
 
-    // Recursively run next middleware
-    await runMiddlewares(req, res, middlewares, currentMiddlewareIndex + 1);
+      // Recursively run next middleware
+      await runMiddlewares(req, res, middlewares, currentMiddlewareIndex + 1, errorHandler);
+    };
+
+    // Initializes middleware chain - the next function will
+    // recursively run next middleware when called by the current middleware
+    await middlewares[currentMiddlewareIndex](req, res, next);
   };
 
-  // Initializes middleware chain - the next function will
-  // recursively run next middleware when called by the current middleware
-  await middlewares[currentMiddlewareIndex](req, res, next);
+  if (errorHandler) {
+    try {
+      await middleware();
+    } catch (error) {
+      errorHandler(res, error);
+    }
+  } else {
+    await middleware();
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,9 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export type Next = () => Promise<void>;
 
-export type Middleware<RequestT extends NextApiRequest = NextApiRequest> = (
-  req: RequestT,
-  res: NextApiResponse,
-  next: Next
-) => Promise<void>;
+export type Middleware<
+  RequestT extends NextApiRequest = NextApiRequest,
+  ResponseT extends NextApiResponse = NextApiResponse
+> = (req: RequestT, res: ResponseT, next: Next) => Promise<void>;
+
+export type ErrorHandler = (res: NextApiResponse, error: unknown) => Promise<void>;

--- a/src/use.ts
+++ b/src/use.ts
@@ -1,9 +1,21 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { runMiddlewares } from './run-middlewares';
-import { Middleware } from './types';
+import { ErrorHandler, Middleware } from './types';
 
 export function use<RequestT extends NextApiRequest>(...middlewares: Middleware<RequestT>[]) {
   return async function internalHandler(req: RequestT, res: NextApiResponse) {
     await runMiddlewares<RequestT>(req, res, middlewares, 0);
+  };
+}
+
+export function withErrorHandler<RequestT extends NextApiRequest>({
+  errorHandler,
+  middlewares,
+}: {
+  errorHandler: ErrorHandler;
+  middlewares: Middleware<RequestT>[];
+}) {
+  return async function internalHandler(req: RequestT, res: NextApiResponse) {
+    await runMiddlewares<RequestT>(req, res, middlewares, 0, errorHandler);
   };
 }


### PR DESCRIPTION
## What?
keeps "use" as it's currently is and add a new method "withErrorHandler".
removes "run-middlewares" from global export as its supposed to be used internally only

## Why?
The current way its pointed in the docs to handle errors will only catch error for the first midleware, unless you pass "captureErrors" multiple times ex: `use(captureErrors, allowMethods(['GET']), captureErrors, addhUser, captureErrors, handler)`

## How?
"withErrorHandler" works encapsulating every midleware on its own trycatch and invoking inside catch `errorHandler(res,error)`

```
if (errorHandler) {
  try {
    await middleware()
  } catch (error) {
    errorHandler(res, error)
  }
} else {
  await middleware()
}
```

